### PR TITLE
Compile on more recent Linux distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ execute_process(COMMAND lsb_release -sc
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_${_distro}")
 message("Compiling for Ubuntu version ${_distro}")
 
-find_package(Eigen REQUIRED)
-include_directories(${EIGEN_INCLUDE_DIR})
+find_package(Eigen3 REQUIRED)
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 find_package(OpenMP QUIET)
 if(OPENMP_FOUND)

--- a/include/render_kinect/objectMeshModel.h
+++ b/include/render_kinect/objectMeshModel.h
@@ -46,6 +46,10 @@
 #include "assimp/cimport.h"
 #include "assimp/postprocess.h"
 #include "assimp/scene.h"
+#else
+#include "assimp/cimport.h"
+#include "assimp/postprocess.h"
+#include "assimp/scene.h"
 #endif
 
 #include <Eigen/Dense>


### PR DESCRIPTION
Small fix to find Eigen3 and load assimp header on alternative or more recent Ubuntu versions.